### PR TITLE
Use a dynamic work queue

### DIFF
--- a/src/ammonite/core/threadManager.cpp
+++ b/src/ammonite/core/threadManager.cpp
@@ -1,5 +1,7 @@
 #include <atomic>
 #include <cstring>
+#include <mutex>
+#include <queue>
 #include <thread>
 
 #include "../types.hpp"
@@ -7,8 +9,6 @@
 #include "../utils/logging.hpp"
 
 #define MAX_EXTRA_THREADS 512
-//Max of 2,097,152 work items
-#define QUEUE_SIZE (2 << 20)
 
 namespace {
   struct WorkItem {
@@ -19,63 +19,41 @@ namespace {
 
   class WorkQueue {
   private:
-    WorkItem* workItems;
-    bool* readyPtr;
-    int queueSize;
-
-    std::atomic<unsigned int> nextWrite = 0;
-    unsigned int nextRead = 0;
-    std::mutex readLock;
+    std::mutex queueLock;
+    std::queue<WorkItem> workItems;
 
   public:
-    WorkQueue(int size) {
-      workItems = new WorkItem[size];
-      readyPtr = new bool[size];
-      std::memset(workItems, 0, size * sizeof(WorkItem));
-      std::memset(readyPtr, 0, size * sizeof(bool));
-      queueSize = size;
-
-      if (((size & (size - 1)) != 0) && size != 0) {
-        ammonite::utils::warning << "Queue size must be a non-zero power of 2, good luck" \
-                                 << std::endl;
-      }
-    }
-
-    ~WorkQueue() {
-      delete [] workItems;
-    }
-
-    void pop(WorkItem* workPtr) {
-      readLock.lock();
-      int index = (nextRead) & (queueSize - 1);
-
-      //Return the work item or an empty one
-      if (readyPtr[index]) {
-        nextRead++;
-        readLock.unlock();
-        readyPtr[index] = false;
-        *workPtr = workItems[index];
-      } else {
-        readLock.unlock();
-        *workPtr = {nullptr, nullptr, nullptr};
-      }
-    }
-
     void push(AmmoniteWork work, void* userPtr, std::atomic_flag* completion) {
-      int index = (nextWrite++) & (queueSize - 1);
-      workItems[index] = {work, userPtr, completion};
-      readyPtr[index] = true;
+      queueLock.lock();
 
-#ifdef DEBUG
-      if (this->getSize() > QUEUE_SIZE) {
-        ammonite::utils::warning << "Queue size exceeded, work items lost" \
-                                 << std::endl;
+      //Add the work to the queue
+      workItems.push({work, userPtr, completion});
+
+      queueLock.unlock();
+    }
+
+    void pop(WorkItem* workItemPtr) {
+      queueLock.lock();
+
+      //Write the work item to workItemPtr if the queue isn't empty
+      if (workItems.empty()) {
+        workItemPtr->work = nullptr;
+      } else {
+        *workItemPtr = workItems.front();
+        workItems.pop();
       }
-#endif
+
+      queueLock.unlock();
     }
 
     int getSize() {
-      return nextWrite - nextRead;
+      int size;
+
+      queueLock.lock();
+      size = workItems.size();
+      queueLock.unlock();
+
+      return size;
     }
   };
 }
@@ -204,7 +182,7 @@ namespace ammonite {
         }
 
         //Create the queue
-        workQueue = new WorkQueue(QUEUE_SIZE);
+        workQueue = new WorkQueue();
 
         //Default to creating a worker thread for every hardware thread
         if (extraThreads == 0) {
@@ -284,26 +262,10 @@ namespace ammonite {
       bool debugCheckRemainingWork(bool verbose) {
         bool issuesFound = false;
 
-        if (workQueue->getSize() != 0) {
+        if (jobCount != 0) {
           issuesFound = true;
           if (verbose) {
-            ammoniteInternalDebug << "WARNING: Work queue not empty (" << workQueue->getSize() \
-                                  << " jobs left)" << std::endl;
-          }
-        }
-
-        if (workQueue->getSize() != jobCount) {
-          issuesFound = true;
-          if (verbose) {
-            ammoniteInternalDebug << "WARNING: Work queue size and job count don't match (" \
-                                  << workQueue->getSize() << " vs " << jobCount << ")" << std::endl;
-          }
-        }
-
-        if (jobCount < 0) {
-          issuesFound = true;
-          if (verbose) {
-            ammoniteInternalDebug << "WARNING: Job count is negative (" \
+            ammoniteInternalDebug << "WARNING: Job count is non-zero (" \
                                   << jobCount << ")" << std::endl;
           }
         }

--- a/src/ammonite/core/threadManager.cpp
+++ b/src/ammonite/core/threadManager.cpp
@@ -164,27 +164,9 @@ namespace ammonite {
         jobCount.notify_one();
       }
 
-      //Specialised variants to submit multiple jobs
-      void submitMultiple(AmmoniteWork work, int newJobs) {
-        workQueue->pushMultiple(work, nullptr, 0, nullptr, newJobs);
-        jobCount += newJobs;
-        jobCount.notify_all();
-      }
-
-      void submitMultipleUser(AmmoniteWork work, void** userPtrs, int stride, int newJobs) {
-        workQueue->pushMultiple(work, userPtrs, stride, nullptr, newJobs);
-        jobCount += newJobs;
-        jobCount.notify_all();
-      }
-
-      void submitMultipleComp(AmmoniteWork work, std::atomic_flag* completions, int newJobs) {
-        workQueue->pushMultiple(work, nullptr, 0, completions, newJobs);
-        jobCount += newJobs;
-        jobCount.notify_all();
-      }
-
-      void submitMultipleUserComp(AmmoniteWork work, void** userPtrs, int stride,
-                                  std::atomic_flag* completions, int newJobs) {
+      //Submit multiple jobs without locking multiple times
+      void submitMultiple(AmmoniteWork work, void** userPtrs, int stride,
+                          std::atomic_flag* completions, int newJobs) {
         workQueue->pushMultiple(work, userPtrs, stride, completions, newJobs);
         jobCount += newJobs;
         jobCount.notify_all();

--- a/src/ammonite/core/threadManager.cpp
+++ b/src/ammonite/core/threadManager.cpp
@@ -75,16 +75,6 @@ namespace {
 
       queueLock.unlock();
     }
-
-    int getSize() {
-      int size;
-
-      queueLock.lock();
-      size = workItems.size();
-      queueLock.unlock();
-
-      return size;
-    }
   };
 }
 

--- a/src/ammonite/core/threadManager.cpp
+++ b/src/ammonite/core/threadManager.cpp
@@ -32,12 +32,12 @@ namespace {
       queueLock.unlock();
     }
 
-    void pushMultiple(AmmoniteWork work, void** userPtrs, int stride,
+    void pushMultiple(AmmoniteWork work, void* userBuffer, int stride,
                        std::atomic_flag* completions, int count) {
       queueLock.lock();
 
       //Avoid running the same checks for every job in the group
-      if (userPtrs == nullptr) {
+      if (userBuffer == nullptr) {
         if (completions == nullptr) {
           for (int i = 0; i < count; i++) {
             workItems.push({work, nullptr, nullptr});
@@ -50,11 +50,11 @@ namespace {
       } else {
         if (completions == nullptr) {
           for (int i = 0; i < count; i++) {
-            workItems.push({work, (void**)((char*)userPtrs + (i * stride)), nullptr});
+            workItems.push({work, (void*)((char*)userBuffer + (i * stride)), nullptr});
           }
         } else {
           for (int i = 0; i < count; i++) {
-            workItems.push({work, (void**)((char*)userPtrs + (i * stride)), completions + i});
+            workItems.push({work, (void*)((char*)userBuffer + (i * stride)), completions + i});
           }
         }
       }
@@ -171,9 +171,9 @@ namespace ammonite {
       }
 
       //Submit multiple jobs without locking multiple times
-      void submitMultiple(AmmoniteWork work, void** userPtrs, int stride,
+      void submitMultiple(AmmoniteWork work, void* userBuffer, int stride,
                           std::atomic_flag* completions, int newJobs) {
-        workQueue->pushMultiple(work, userPtrs, stride, completions, newJobs);
+        workQueue->pushMultiple(work, userBuffer, stride, completions, newJobs);
         jobCount += newJobs;
         jobCount.notify_all();
       }

--- a/src/ammonite/core/threadManager.hpp
+++ b/src/ammonite/core/threadManager.hpp
@@ -15,7 +15,7 @@ namespace ammonite {
       void destroyThreadPool();
 
       void submitWork(AmmoniteWork work, void* userPtr, std::atomic_flag* completion);
-      void submitMultiple(AmmoniteWork work, void** userPtrs, int stride,
+      void submitMultiple(AmmoniteWork work, void* userBuffer, int stride,
                           std::atomic_flag* completions, int jobCount);
 
       void blockThreads(bool sync);

--- a/src/ammonite/core/threadManager.hpp
+++ b/src/ammonite/core/threadManager.hpp
@@ -15,11 +15,8 @@ namespace ammonite {
       void destroyThreadPool();
 
       void submitWork(AmmoniteWork work, void* userPtr, std::atomic_flag* completion);
-      void submitMultiple(AmmoniteWork work, int jobCount);
-      void submitMultipleUser(AmmoniteWork work, void** userPtrs, int stride, int jobCount);
-      void submitMultipleComp(AmmoniteWork work, std::atomic_flag* completions, int jobCount);
-      void submitMultipleUserComp(AmmoniteWork work, void** userPtrs, int stride,
-                                  std::atomic_flag* completions, int jobCount);
+      void submitMultiple(AmmoniteWork work, void** userPtrs, int stride,
+                          std::atomic_flag* completions, int jobCount);
 
       void blockThreads(bool sync);
       void unblockThreads(bool sync);

--- a/src/ammonite/lighting/lighting.cpp
+++ b/src/ammonite/lighting/lighting.cpp
@@ -168,7 +168,7 @@ namespace ammonite {
           workerData[i].shadowProj = &shadowProj;
           workerData[i].i = i;
         }
-        ammonite::thread::internal::submitMultiple(lightWork, (void**)&workerData[0],
+        ammonite::thread::internal::submitMultiple(lightWork, (void*)&workerData[0],
                                                    sizeof(LightWorkerData),
                                                    &syncs[0], lightCount);
 

--- a/src/ammonite/lighting/lighting.cpp
+++ b/src/ammonite/lighting/lighting.cpp
@@ -168,9 +168,9 @@ namespace ammonite {
           workerData[i].shadowProj = &shadowProj;
           workerData[i].i = i;
         }
-        ammonite::thread::internal::submitMultipleUserComp(lightWork, (void**)&workerData[0],
-                                                           sizeof(LightWorkerData),
-                                                           &syncs[0], lightCount);
+        ammonite::thread::internal::submitMultiple(lightWork, (void**)&workerData[0],
+                                                   sizeof(LightWorkerData),
+                                                   &syncs[0], lightCount);
 
         for (unsigned int i = 0; i < lightCount; i++) {
           syncs[i].wait(false);

--- a/src/ammonite/thread.cpp
+++ b/src/ammonite/thread.cpp
@@ -16,22 +16,10 @@ namespace ammonite {
       internal::submitWork(work, userPtr, completion);
     }
 
+    //userPtrs and completions may be null
     void submitMultiple(AmmoniteWork work, void** userPtrs, int stride,
                         std::atomic_flag* completions, int jobCount) {
-      if (userPtrs == nullptr) {
-        if (completions == nullptr) {
-          ammonite::thread::internal::submitMultiple(work, jobCount);
-        } else {
-          ammonite::thread::internal::submitMultipleComp(work, completions, jobCount);
-        }
-      } else {
-        if (completions == nullptr) {
-          ammonite::thread::internal::submitMultipleUser(work, userPtrs, stride, jobCount);
-        } else {
-          ammonite::thread::internal::submitMultipleUserComp(work, userPtrs, stride,
-                                                             completions, jobCount);
-        }
-      }
+      ammonite::thread::internal::submitMultiple(work, userPtrs, stride, completions, jobCount);
     }
 
     void waitWorkComplete(std::atomic_flag* completion) {

--- a/src/ammonite/thread.cpp
+++ b/src/ammonite/thread.cpp
@@ -16,10 +16,10 @@ namespace ammonite {
       internal::submitWork(work, userPtr, completion);
     }
 
-    //userPtrs and completions may be null
-    void submitMultiple(AmmoniteWork work, void** userPtrs, int stride,
+    //userBuffer and completions may be null
+    void submitMultiple(AmmoniteWork work, void* userBuffer, int stride,
                         std::atomic_flag* completions, int jobCount) {
-      ammonite::thread::internal::submitMultiple(work, userPtrs, stride, completions, jobCount);
+      ammonite::thread::internal::submitMultiple(work, userBuffer, stride, completions, jobCount);
     }
 
     void waitWorkComplete(std::atomic_flag* completion) {

--- a/src/ammonite/thread.hpp
+++ b/src/ammonite/thread.hpp
@@ -10,7 +10,7 @@ namespace ammonite {
     unsigned int getThreadPoolSize();
     void submitWork(AmmoniteWork work, void* userPtr);
     void submitWork(AmmoniteWork work, void* userPtr, std::atomic_flag* completion);
-    void submitMultiple(AmmoniteWork work, void** userPtrs, int stride,
+    void submitMultiple(AmmoniteWork work, void* userBuffer, int stride,
                         std::atomic_flag* completions, int jobCount);
     void waitWorkComplete(std::atomic_flag* completion);
 

--- a/src/threadDemo.cpp
+++ b/src/threadDemo.cpp
@@ -233,7 +233,7 @@ namespace {
     RESET_TIMERS
     bool passed = true;
     int* values = new int[jobCount]{};
-    ammonite::thread::submitMultiple(shortTask, (void**)&values[0],
+    ammonite::thread::submitMultiple(shortTask, (void*)&values[0],
                                      sizeof(int), &syncs[0], jobCount);
     submitTimer.pause();
 
@@ -254,7 +254,7 @@ namespace {
     RESET_TIMERS
     bool passed = true;
     int* values = new int[jobCount]{};
-    ammonite::thread::submitMultiple(shortTask, (void**)&values[0],
+    ammonite::thread::submitMultiple(shortTask, (void*)&values[0],
                                      sizeof(int), nullptr, jobCount);
     submitTimer.pause();
 


### PR DESCRIPTION
Avoids allocating 50MB of space at the cost of locking, seems to fix some leaks