### PR TITLE
Keep next element of work queue empty

### DIFF
--- a/src/ammonite/core/threadManager.cpp
+++ b/src/ammonite/core/threadManager.cpp
@@ -24,15 +24,14 @@ namespace {
   class WorkQueue {
   private:
     std::mutex readLock;
-    Node* lastPopped;
-    std::atomic<Node*> lastPushed;
+    Node* nextPopped;
+    std::atomic<Node*> nextPushed;
 
   public:
     WorkQueue() {
       //Start with an empty queue, 1 'old' node
-      lastPushed = new Node;
-      lastPopped = lastPushed;
-      lastPushed.load()->nextNode = nullptr;
+      nextPushed = new Node{{nullptr, nullptr, nullptr}, nullptr};
+      nextPopped = nextPushed;
     }
 
     ~WorkQueue() {
@@ -44,16 +43,17 @@ namespace {
     }
 
     void push(AmmoniteWork work, void* userPtr, std::atomic_flag* completion) {
-      //Create the new node, fill with data
-      Node* newNode = new Node{{work, userPtr, completion}, nullptr};
+      //Create a new empty node
+      Node* newNode = new Node{{nullptr, nullptr, nullptr}, nullptr};
 
-      //Atomically add the node to the previous node
-      lastPushed.exchange(newNode)->nextNode = newNode;
+      //Atomically the next node to newNode, then fill in the old new node
+      *(nextPushed.exchange(newNode)) = {{work, userPtr, completion}, newNode};
     }
 
     void pushMultiple(AmmoniteWork work, void* userBuffer, int stride,
                        std::atomic_flag* completions, int count) {
       //Generate section of linked list to insert
+      Node* newNode = new Node{{nullptr, nullptr, nullptr}, nullptr};
       Node sectionStart;
       Node* sectionPtr = &sectionStart;
       if (userBuffer == nullptr) {
@@ -85,21 +85,22 @@ namespace {
       }
 
       //Insert the generated section atomically
-      lastPushed.exchange(sectionPtr)->nextNode = sectionStart.nextNode;
+      sectionPtr->nextNode = newNode;
+      *(nextPushed.exchange(newNode)) = *sectionStart.nextNode;
     }
 
     void pop(WorkItem* workItemPtr) {
       //Use the most recently popped node to find the next
       readLock.lock();
-      Node* nextNode = lastPopped->nextNode;
 
       //Copy the data and free the old node, otherwise return if we don't have a new node
-      if (nextNode != nullptr) {
-        Node* oldNode = lastPopped;
-        *workItemPtr = nextNode->workItem;
-        lastPopped = nextNode;
+      Node* currentNode = nextPopped;
+      if (currentNode->nextNode != nullptr) {
+        nextPopped = nextPopped->nextNode;
         readLock.unlock();
-        delete oldNode;
+
+        *workItemPtr = currentNode->workItem;
+        delete currentNode;
       } else {
         readLock.unlock();
         workItemPtr->work = nullptr;

--- a/src/ammonite/core/threadManager.cpp
+++ b/src/ammonite/core/threadManager.cpp
@@ -40,6 +40,9 @@ namespace {
       do {
         this->pop(&workItem);
       } while (workItem.work != nullptr);
+
+      //Clear up next free node
+      delete nextPopped;
     }
 
     void push(AmmoniteWork work, void* userPtr, std::atomic_flag* completion) {
@@ -87,6 +90,7 @@ namespace {
       //Insert the generated section atomically
       sectionPtr->nextNode = newNode;
       *(nextPushed.exchange(newNode)) = *sectionStart.nextNode;
+      delete sectionStart.nextNode;
     }
 
     void pop(WorkItem* workItemPtr) {


### PR DESCRIPTION
Keep the next element read to add and empty, simplifies and speeds up some code paths