### PR TITLE
Support clang-tidy, add a linting target and workflow 

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,3 @@
+---
+WarningsAsErrors: 'true,*'
+---

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,3 +1,4 @@
 ---
+Checks: '-clang-diagnostic-#pragma-messages'
 WarningsAsErrors: 'true,*'
 ---

--- a/.github/workflows/run-clang-tidy.yml
+++ b/.github/workflows/run-clang-tidy.yml
@@ -1,0 +1,23 @@
+name: Clang-tidy linting
+
+on:
+  push:
+    branches: '**'
+  pull_request:
+    branches: '**'
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install build dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install --no-install-recommends make pkg-config build-essential
+        sudo apt-get install --no-install-recommends clang-tidy-18
+        sudo apt-get install --no-install-recommends libglm-dev libglfw3-dev libglew-dev libstb-dev libassimp-dev
+
+    - name: Run the linting target
+      run: |
+        make lint -j$(nproc)

--- a/.github/workflows/run-clang-tidy.yml
+++ b/.github/workflows/run-clang-tidy.yml
@@ -1,3 +1,4 @@
+# This workflow will lint the project using clang-tidy
 name: Clang-tidy linting
 
 on:
@@ -7,7 +8,7 @@ on:
     branches: '**'
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ $(OBJECT_DIR)/threadDemo.o: ./src/threadDemo.cpp $(AMMONITE_HEADER_SOURCE)
 	@mkdir -p "$(OBJECT_DIR)"
 	$(CXX) ./src/threadDemo.cpp -c $(CXXFLAGS) -o "$@"
 
-$(BUILD_DIR)/compile_flags.txt: $(ALL_OBJECTS_SOURCE)
+$(BUILD_DIR)/compile_flags.txt: Makefile
 	@mkdir -p "$(BUILD_DIR)"
 	@rm -fv "$(BUILD_DIR)/compile_flags.txt"
 	@for arg in $(CXXFLAGS); do \

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ DEMO_OBJECTS_SOURCE = $(shell ls ./src/demos/**/*.cpp)
 DEMO_HEADER_SOURCE = $(shell ls ./src/demos/**/*.hpp)
 
 ALL_OBJECTS_SOURCE = $(AMMONITE_OBJECTS_SOURCE) $(HELPER_OBJECTS_SOURCE) $(DEMO_OBJECTS_SOURCE)
+LINT_OBJECTS = $(subst ./src,$(OBJECT_DIR),$(subst .cpp,.linted,$(ALL_OBJECTS_SOURCE)))
 
 OBJECT_DIR = $(BUILD_DIR)/objects
 AMMONITE_OBJECTS = $(subst ./src,$(OBJECT_DIR),$(subst .cpp,.o,$(AMMONITE_OBJECTS_SOURCE)))
@@ -82,6 +83,10 @@ $(BUILD_DIR)/compile_flags.txt: $(ALL_OBJECTS_SOURCE)
 	@for arg in $(CXXFLAGS); do \
 		echo $$arg >> "$(BUILD_DIR)/compile_flags.txt"; \
 	done
+$(OBJECT_DIR)/%.linted: ./src/%.cpp
+	clang-tidy -p "$(BUILD_DIR)" $(subst $(OBJECT_DIR),./src,$(subst .linted,.cpp,$(@)))
+	@mkdir -p "$$(dirname $@)"
+	@touch "$@"
 
 .PHONY: build demo threads debug library headers install uninstall clean lint cache icons $(AMMONITE_HEADER_INSTALL)
 build: demo threads
@@ -117,7 +122,7 @@ uninstall:
 clean: cache
 	@rm -rfv "$(BUILD_DIR)"
 lint: $(BUILD_DIR)/compile_flags.txt
-	clang-tidy -p "$(BUILD_DIR)" $(ALL_OBJECTS_SOURCE)
+	@$(MAKE) $(LINT_OBJECTS)
 cache:
 	@rm -rfv "$(CACHE_DIR)"
 icons:

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,10 @@ HELPER_HEADER_SOURCE = $(shell ls ./src/helper/**/*.hpp)
 DEMO_OBJECTS_SOURCE = $(shell ls ./src/demos/**/*.cpp)
 DEMO_HEADER_SOURCE = $(shell ls ./src/demos/**/*.hpp)
 
-ALL_OBJECTS_SOURCE = $(AMMONITE_OBJECTS_SOURCE) $(HELPER_OBJECTS_SOURCE) $(DEMO_OBJECTS_SOURCE)
+ROOT_OBJECTS_SOURCE = $(shell ls ./src/*.cpp)
+
+ALL_OBJECTS_SOURCE = $(AMMONITE_OBJECTS_SOURCE) $(HELPER_OBJECTS_SOURCE) $(DEMO_OBJECTS_SOURCE) \
+                     $(ROOT_OBJECTS_SOURCE)
 LINT_OBJECTS = $(subst ./src,$(OBJECT_DIR),$(subst .cpp,.linted,$(ALL_OBJECTS_SOURCE)))
 
 OBJECT_DIR = $(BUILD_DIR)/objects

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ $(BUILD_DIR)/compile_flags.txt: $(ALL_OBJECTS_SOURCE)
 	@for arg in $(CXXFLAGS); do \
 		echo $$arg >> "$(BUILD_DIR)/compile_flags.txt"; \
 	done
-$(OBJECT_DIR)/%.linted: ./src/%.cpp $(BUILD_DIR)/compile_flags.txt
+$(OBJECT_DIR)/%.linted: ./src/%.cpp $(BUILD_DIR)/compile_flags.txt .clang-tidy
 	clang-tidy -p "$(BUILD_DIR)" $(subst $(OBJECT_DIR),./src,$(subst .linted,.cpp,$(@)))
 	@mkdir -p "$$(dirname $@)"
 	@touch "$@"

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ HELPER_HEADER_SOURCE = $(shell ls ./src/helper/**/*.hpp)
 DEMO_OBJECTS_SOURCE = $(shell ls ./src/demos/**/*.cpp)
 DEMO_HEADER_SOURCE = $(shell ls ./src/demos/**/*.hpp)
 
+ALL_OBJECTS_SOURCE = $(AMMONITE_OBJECTS_SOURCE) $(HELPER_OBJECTS_SOURCE) $(DEMO_OBJECTS_SOURCE)
+
 OBJECT_DIR = $(BUILD_DIR)/objects
 AMMONITE_OBJECTS = $(subst ./src,$(OBJECT_DIR),$(subst .cpp,.o,$(AMMONITE_OBJECTS_SOURCE)))
 HELPER_OBJECTS = $(subst ./src,$(OBJECT_DIR),$(subst .cpp,.o,$(HELPER_OBJECTS_SOURCE)))
@@ -74,7 +76,14 @@ $(OBJECT_DIR)/threadDemo.o: ./src/threadDemo.cpp $(AMMONITE_HEADER_SOURCE)
 	@mkdir -p "$(OBJECT_DIR)"
 	$(CXX) ./src/threadDemo.cpp -c $(CXXFLAGS) -o "$@"
 
-.PHONY: build demo threads debug library headers install uninstall clean cache icons $(AMMONITE_HEADER_INSTALL)
+$(BUILD_DIR)/compile_flags.txt: $(ALL_OBJECTS_SOURCE)
+	@mkdir -p "$(BUILD_DIR)"
+	@rm -fv "$(BUILD_DIR)/compile_flags.txt"
+	@for arg in $(CXXFLAGS); do \
+		echo $$arg >> "$(BUILD_DIR)/compile_flags.txt"; \
+	done
+
+.PHONY: build demo threads debug library headers install uninstall clean lint cache icons $(AMMONITE_HEADER_INSTALL)
 build: demo threads
 demo: $(BUILD_DIR)/demo
 	@if [[ "$(DEBUG)" != "true" ]]; then \
@@ -107,6 +116,8 @@ uninstall:
 	@if [[ -d "$(HEADER_DIR)/ammonite" ]]; then rm -rf "$(HEADER_DIR)/ammonite"; fi
 clean: cache
 	@rm -rfv "$(BUILD_DIR)"
+lint: $(BUILD_DIR)/compile_flags.txt
+	clang-tidy -p "$(BUILD_DIR)" $(ALL_OBJECTS_SOURCE)
 cache:
 	@rm -rfv "$(CACHE_DIR)"
 icons:

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ $(BUILD_DIR)/compile_flags.txt: $(ALL_OBJECTS_SOURCE)
 	@for arg in $(CXXFLAGS); do \
 		echo $$arg >> "$(BUILD_DIR)/compile_flags.txt"; \
 	done
-$(OBJECT_DIR)/%.linted: ./src/%.cpp
+$(OBJECT_DIR)/%.linted: ./src/%.cpp $(BUILD_DIR)/compile_flags.txt
 	clang-tidy -p "$(BUILD_DIR)" $(subst $(OBJECT_DIR),./src,$(subst .linted,.cpp,$(@)))
 	@mkdir -p "$$(dirname $@)"
 	@touch "$@"
@@ -121,8 +121,7 @@ uninstall:
 	@if [[ -d "$(HEADER_DIR)/ammonite" ]]; then rm -rf "$(HEADER_DIR)/ammonite"; fi
 clean: cache
 	@rm -rfv "$(BUILD_DIR)"
-lint: $(BUILD_DIR)/compile_flags.txt
-	@$(MAKE) $(LINT_OBJECTS)
+lint: $(LINT_OBJECTS)
 cache:
 	@rm -rfv "$(CACHE_DIR)"
 icons:

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@
   - ### Libraries:
     - `libglm-dev libglfw3-dev libglew-dev libstb-dev libassimp-dev`
     - `libdecor-0-0 libdecor-0-plugin-1-gtk` are required for Wayland window decorations
+  - ### Linting:
+    - `clang-tidy`
   - ### Icons:
     - `inkscape optipng`
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@
   - Package names are correct for Debian, other distros may vary
   - `make`
   - `pkg-config`
+  - `coreutils`
   - `g++` **OR** `clang`
     - If using clang, use `CXX="clang++" make [TARGET]`
     - When swapping between different compilers, run `make clean`

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -12,7 +12,7 @@
 
 ## Build system:
   - ### Targets:
-    - `build`, `debug`, `library`, `demo` and `threads` support `-j[CORE COUNT]`
+    - `build`, `debug`, `library`, `demo`, `threads` and `lint` support `-j[CORE COUNT]`
     - `make build` - Builds the demo and thread demo
     - `make debug` - Cleans build directory, then runs `make build` in debug mode
     - `make library` - Builds `build/libammonite.so`
@@ -25,6 +25,7 @@
     - `make uninstall` - Removes installed library
       - Custom install locations can be removed using the environment variable `INSTALL_DIR`
     - `make icons` - Creates `assets/icons/icon-*.png` from `assets/icons/icon.svg`
+    - `make lint` - Lints the project using `clang-tidy`
     - `make clean` - Cleans the build area (`build/`) and default runtime cache (`cache/`)
     - `make cache` - Clears the default runtime binary cache, useful if running into issues with caching
   - ### Flags:

--- a/src/ammonite/graphics/renderHelper.cpp
+++ b/src/ammonite/graphics/renderHelper.cpp
@@ -36,11 +36,9 @@ namespace ammonite {
           static double maxError = (1.0 / 50000.0);
           #define errorAdjustCoeff 1.01
 
-          //Figure out time budget remaining
-          double const targetFrameTime = 1.0 / *frameLimitPtr;
-          double spareTime = targetFrameTime - targetFrameTimer.getTime();
-
           //Sleep for successively shorter intervals until the frametime budget is gone
+          double spareTime;
+          const double targetFrameTime = 1.0 / *frameLimitPtr;
           while (targetFrameTime - targetFrameTimer.getTime() > maxError) {
             spareTime = targetFrameTime - targetFrameTimer.getTime();
             const auto sleepLength = std::chrono::nanoseconds(

--- a/src/ammonite/models/modelLoader.cpp
+++ b/src/ammonite/models/modelLoader.cpp
@@ -63,8 +63,10 @@ namespace ammonite {
           int index = 0;
           for (unsigned int i = 0; i < meshPtr->mNumFaces; i++) {
             aiFace face = meshPtr->mFaces[i];
-            std::memcpy(&newMesh->indices[index], &face.mIndices[0],
-                        face.mNumIndices * sizeof(unsigned int));
+            if (&face.mIndices[0] != nullptr) {
+              std::memcpy(&newMesh->indices[index], &face.mIndices[0],
+                          face.mNumIndices * sizeof(unsigned int));
+            }
             index += face.mNumIndices;
           }
 


### PR DESCRIPTION
Begin linting the project with `clang-tidy` and a minimal config.
Adds `make lint`, checks it in a new workflow

Closes #18